### PR TITLE
Comment out update "this.current.enabled = false" to fix hindered navigation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,9 @@ class FileBrowser {
     }
 
     async update() {
-        this.current.enabled = false;
+        // FIXME: temporary and UGLY fix of https://github.com/bodil/vscode-file-browser/issues/35.
+        // Brought in from here https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713.
+        // this.current.enabled = false;
         this.current.show();
         this.current.busy = true;
         this.current.title = this.path.fsPath;


### PR DESCRIPTION
This is really just a workaround brought in form [here](https://github.com/atariq11700/vscode-file-browser/commit/a2525d01f262f17dac2c478e56640c9ce1f65713) to be able to navigate around.

JFYI [the fork from where the fix came from](https://github.com/atariq11700/vscode-file-browser) doesn't seem to work due to the following error:
```
Error: dlopen(~/.vscode-insiders/extensions/atariq11700.file-browser-fixed-0.2.14/node_modules/drivelist/build/Release/drivelist.node, 0x0001))
```

I hope this will help :)